### PR TITLE
feat: add homepage layout

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -39,13 +39,13 @@ android {
         create("remoteServer") {
             dimension = "default"
             isDefault = true
-            buildConfigField("String", "BASE_URL", "\"https://todos.webcloudpower.com\"")
+            buildConfigField("String", "BASE_URL", "\"https://todos.webcloudpower.com/lists\"")
         }
         create("localServer") {
             dimension = "default"
             applicationIdSuffix = "localServer"
             versionNameSuffix = "-localServer"
-            buildConfigField("String", "BASE_URL", "\"http://10.0.2.2:3000\"")
+            buildConfigField("String", "BASE_URL", "\"http://10.0.2.2:3000/lists\"")
         }
     }
 

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -37,7 +37,7 @@ module Authentication
     end
 
     def after_authentication_url
-      session.delete(:return_to_after_authenticating) || root_url
+      session.delete(:return_to_after_authenticating) || lists_url
     end
 
 

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,4 +1,5 @@
 class PasswordsController < ApplicationController
+  layout "homepage"
   allow_unauthenticated_access
   before_action :set_user_by_token, only: %i[ edit update ]
 

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,4 +1,5 @@
 class RegistrationsController < ApplicationController
+  layout "homepage"
   allow_unauthenticated_access only: %i[ new create ]
   rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_registration_url, alert: "Try again later." }
 
@@ -10,7 +11,8 @@ class RegistrationsController < ApplicationController
     @user = User.new(registration_params)
 
     if @user.save
-      redirect_to root_path, notice: "Registered successfully."
+      start_new_session_for @user
+      redirect_to lists_path, notice: "Registered successfully."
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,8 +1,10 @@
-class SessionsController < ApplicationController
+class SessionsController < WelcomeController
+  layout "homepage"
   allow_unauthenticated_access only: %i[ new create ]
   rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_url, alert: "Try again later." }
 
   def new
+    redirect_to after_authentication_url if authenticated?
   end
 
   def create

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,0 +1,7 @@
+class WelcomeController < ApplicationController
+  layout "homepage"
+  allow_unauthenticated_access only: %i[ index ]
+
+  def index
+  end
+end

--- a/app/helpers/buttons_helper.rb
+++ b/app/helpers/buttons_helper.rb
@@ -1,8 +1,4 @@
 module ButtonsHelper
-  def turbo_native_app?
-    request.user_agent.to_s.include? "Turbo Native"
-  end
-
   def icon(name, **args)
     file_path = File.read(Rails.root.join("app", "assets", "icons", "#{name}.svg"))
     svg_file = Nokogiri::HTML::DocumentFragment.parse(file_path).at_css("svg")

--- a/app/views/layouts/_headers.html.erb
+++ b/app/views/layouts/_headers.html.erb
@@ -1,4 +1,4 @@
-<title><%= content_for(:title) || "Todos" %></title>
+<title><%= content_for(:title) || "Litensio" %></title>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="mobile-web-app-capable" content="yes">

--- a/app/views/layouts/_headers.html.erb
+++ b/app/views/layouts/_headers.html.erb
@@ -1,0 +1,23 @@
+<title><%= content_for(:title) || "Todos" %></title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="mobile-web-app-capable" content="yes">
+<%= csrf_meta_tags %>
+<%= csp_meta_tag %>
+
+<% turbo_refreshes_with method: :morph, scroll: :preserve %>
+
+<%= yield :head %>
+
+<%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>
+<%#= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>
+
+<link rel="icon" href="/icon.png" type="image/png">
+<link rel="icon" href="/icon.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="/icon.png">
+
+<%# Includes all stylesheet files in app/assets/stylesheets %>
+<%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
+<%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+
+<%= javascript_importmap_tags %>

--- a/app/views/layouts/_homepage_navbar.html.erb
+++ b/app/views/layouts/_homepage_navbar.html.erb
@@ -1,0 +1,16 @@
+<nav class="flex pt-4 pb-4 border-b border-grep-500 bg-white w-full fixed">
+  <div class="container mx-auto px-5 flex ">
+    <div class="flex-none inline-flex items-center font-medium text-lg">
+      <%= icon "home", class: "w-3 h-3 me-2.5" %>
+      <%= link_to "Litensio", root_path %>
+    </div>
+    <div class="grow"></div>
+    <div class="flex-none">
+      <%= link_to "Log in", new_session_path, class: "px-5 py-2.5 hover:text-blue-500" %>
+    </div>
+    <div class="flex-none ml-2">
+      <%= link_to "Sign up", new_registration_path, class: "font-medium border-solid border-2 rounded-lg border-blue-500 hover:bg-blue-500 text-blue-500 hover:text-white px-5 py-2.5 transition-all ease-in duration-150" %>
+    </div>
+  </div>
+</nav>
+<div class="h-16"></div>

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -4,13 +4,10 @@
     <%= render "layouts/headers" %>
   </head>
 
-  <body class="<%= turbo_native_app? ? "turbo-native" : "" %>">
-    <% if authenticated? %>
-      <%= render "layouts/navbar" %>
+  <body>
+    <% if !turbo_native_app? %>
+      <%= render "layouts/homepage_navbar" %>
     <% end %>
-
-    <%= turbo_frame_tag "modal" %>
-
     <main class="container mx-auto mt-2 px-5 flex">
       <div class="w-full h-full">
         <% if notice.present? %>
@@ -21,7 +18,7 @@
           <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block" id="alert"><%= alert %></p>
         <% end %>
 
-        <% if !authenticated? && !turbo_native_app? %>
+        <% if !turbo_native_app? %>
           <h1 class="font-bold text-2xl"><%= yield :title %></h1>
         <% end %>
 

--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -1,5 +1,5 @@
 {
-  "name": "Todos",
+  "name": "Litensio",
   "icons": [
     {
       "src": "/icon.png",

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">Welcome#index</h1>
+  <p>Find me in app/views/welcome/index.html.erb</p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,17 +2,13 @@ Rails.application.routes.draw do
   resource :registration
   resource :session
   resources :passwords, param: :token
-  resources :lists, only: [ :index, :create ], path: "/"
 
-  resources :lists, except: [ :index, :create ] do
+  resources :lists do
     resources :items, only: %i[new create]
   end
 
   resources :items, only: %i[edit update destroy]
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
@@ -20,5 +16,5 @@ Rails.application.routes.draw do
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   # Defines the root path route ("/")
-  root "lists#index"
+  root "welcome#index"
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -42,7 +42,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   end
 
   def sign_in(user)
-    visit root_path
+    visit lists_path
     fill_in "email_address", with: user.email_address
     fill_in "password", with: "password"
     click_on "Sign in"

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -17,6 +17,6 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
       }
     end
 
-    assert_redirected_to root_url
+    assert_redirected_to lists_url
   end
 end

--- a/test/controllers/welcome_controller_test.rb
+++ b/test/controllers/welcome_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class WelcomeControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get root_url
+    assert_response :success
+  end
+end

--- a/test/system/registrations_test.rb
+++ b/test/system/registrations_test.rb
@@ -6,7 +6,8 @@ class RegistrationsTest < ApplicationSystemTestCase
   end
 
   test "should create user" do
-    visit new_registration_url
+    visit root_url
+    click_on "Sign up"
 
     fill_in "Email", with: "test@example.com"
     fill_in "Password", with: "testtest"
@@ -17,7 +18,8 @@ class RegistrationsTest < ApplicationSystemTestCase
   end
 
   test "when form is invalid, shows error" do
-    visit new_registration_url
+    visit root_url
+    click_on "Sign up"
 
     fill_in "Email", with: @user.email_address
     fill_in "Password", with: "testtest"

--- a/test/system/session_test.rb
+++ b/test/system/session_test.rb
@@ -7,6 +7,7 @@ class SessionTest < ApplicationSystemTestCase
 
   test "signin in and signout" do
     visit root_url
+    click_on "Log in"
 
     fill_in "email_address", with: @user.email_address
     fill_in "password", with: "password"


### PR DESCRIPTION
Add layout used for public (without login)
pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a new welcome page with a homepage layout.
  - Introduced a new navigation bar for authentication flows.

- **User Experience**
  - Updated authentication redirects to go to lists page after login/registration.
  - Improved mobile responsiveness with new meta tags.
  - Changed application branding to "Litensio" in the PWA manifest.

- **Routes**
  - Modified application routing to use welcome page as root.
  - Enabled full CRUD functionality for lists resource.

- **Testing**
  - Added new system and controller tests for welcome page and authentication flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->