### PR TITLE
feat: sort lists and items by created_at: :desc

### DIFF
--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -4,7 +4,7 @@ class ListsController < ApplicationController
 
   # GET /lists or /lists.json
   def index
-    @lists = Current.user.lists
+    @lists = Current.user.lists.order(created_at: :desc)
   end
 
   # GET /lists/1 or /lists/1.json

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -6,7 +6,7 @@
     </div>
     <input type="hidden" name="no_flash" value=1 />
   <% end %>
-  <div class="grow">
+  <div data-test="item-name" class="grow">
     <%= item.name %> 
   </div>
   <div class="flex-none flex space-x-1">

--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, @list.name %>
 
 <ul class="items w-full divide-y divide-gray-200">
-  <% @list.items.each do |item| %>
+  <% @list.items.order(created_at: :desc).each do |item| %>
     <%= render item %>
   <% end %>
 </ul>

--- a/test/controllers/lists_controller_test.rb
+++ b/test/controllers/lists_controller_test.rb
@@ -9,10 +9,15 @@ class ListsControllerTest < ApplicationIntegrationTest
   end
 
   test "should get index" do
+    List.create!(name: "new", user: @user)
+
     get lists_url
 
     assert_response :success
-    assert_includes response.body, "one"
+
+    assert_select "main li:nth-of-type(1) a", "new"
+    assert_select "main li:nth-of-type(2) a", "two"
+    assert_select "main li:nth-of-type(3) a", "one"
     assert_not_includes response.body, "third"
   end
 
@@ -30,8 +35,12 @@ class ListsControllerTest < ApplicationIntegrationTest
   end
 
   test "should show list" do
+    Item.create!(name: "new", list: @list)
+
     get list_url(@list)
     assert_response :success
+
+    assert_select "main li:first-of-type [data-test='item-name']", "new"
   end
 
   test "should get edit" do

--- a/test/fixtures/items.yml
+++ b/test/fixtures/items.yml
@@ -3,11 +3,17 @@
 one:
   name: one
   list: one
+  created_at: <%= 3.minutes.ago %>
+  updated_at: <%= 3.minutes.ago %>
 
 two:
   name: two
   list: two
+  created_at: <%= 2.minutes.ago %>
+  updated_at: <%= 2.minutes.ago %>
 
 third:
   name: third
   list: third
+  created_at: <%= 1.minutes.ago %>
+  updated_at: <%= 1.minutes.ago %>

--- a/test/fixtures/lists.yml
+++ b/test/fixtures/lists.yml
@@ -3,11 +3,17 @@
 one:
   name: one
   user: one 
+  created_at: <%= 3.minutes.ago %>
+  updated_at: <%= 3.minutes.ago %>
 
 two:
   name: two
   user: one 
+  created_at: <%= 2.minutes.ago %>
+  updated_at: <%= 2.minutes.ago %>
 
 third:
   name: third
   user: two 
+  created_at: <%= 1.minute.ago %>
+  updated_at: <%= 1.minute.ago %>


### PR DESCRIPTION
We do this to make new records to appear at the beginning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added sorting for lists and items by creation date, displaying most recent items first.
  
- **Bug Fixes**
  - None

- **Tests**
  - Enhanced test coverage for list and item display, including new assertions for recently created entities.
  
- **Chores**
  - Added timestamps to test fixtures for improved temporal context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->