### PR TITLE
feat: remove confusing home icon on public pages

### DIFF
--- a/app/views/layouts/_homepage_navbar.html.erb
+++ b/app/views/layouts/_homepage_navbar.html.erb
@@ -1,6 +1,5 @@
 <nav class="flex pt-4 pb-4 border-b border-grep-500 bg-white w-full fixed h-16 px-5">
   <div class="flex-none inline-flex items-center font-medium text-lg text-blue-500">
-    <%= icon "home", class: "w-3 h-3 me-2.5" %>
     <%= link_to "Litensio", root_path %>
   </div>
   <div class="grow"></div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Removed the "home" icon from the homepage navbar, displaying only the "Litensio" text link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->