### PR TITLE
fix: only enable native modal when explicit enabled

### DIFF
--- a/android/app/src/main/assets/json/configuration.json
+++ b/android/app/src/main/assets/json/configuration.json
@@ -6,7 +6,9 @@
       ],
       "properties": {
         "context": "default",
-        "pull_to_refresh_enabled": true
+        "uri": "hotwire://fragment/web",
+        "pull_to_refresh_enabled": true,
+        "presentation": "default"
       }
     },
     {
@@ -15,6 +17,7 @@
       ],
       "properties": {
         "context": "default",
+        "uri": "hotwire://fragment/web",
         "pull_to_refresh_enabled": true,
         "presentation": "replace_root"
       }

--- a/android/app/src/main/java/com/aronwolf/todos/TodoApplication.kt
+++ b/android/app/src/main/java/com/aronwolf/todos/TodoApplication.kt
@@ -33,5 +33,6 @@ class TodoApplication : Application() {
 
         Hotwire.config.debugLoggingEnabled = true
         Hotwire.config.webViewDebuggingEnabled = true
+        Hotwire.config.applicationUserAgentPrefix = "feature-flag-native-modals;"
     }
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,8 +3,8 @@ module ApplicationHelper
     request.user_agent.to_s.include? "Turbo Native"
   end
 
-  def hotwire_native_modal?
-    request.user_agent.to_s.include?("overflow-menu")
+  def feature_flag_native_modals_enabled?
+    request.user_agent.to_s.include?("feature-flag-native-modals")
   end
 
   def icon(name, **args)

--- a/app/helpers/buttons_helper.rb
+++ b/app/helpers/buttons_helper.rb
@@ -16,19 +16,24 @@ module ButtonsHelper
             "text-white block font-medium"
 
     content_tag :div, "", class: "float-right w-12" do
-      link_to path, class: clazz, data: new_button_data do
+      link_to path, class: clazz, data: button_data do
         icon "plus", class: "w-6 h-6"
       end
     end
   end
 
+  def edit_button(path)
+    link_to "Edit", path, data: button_data({ action: "dropdown#toggle" }),
+            class: "edit block px-4 py-2 hover:bg-gray-100"
+  end
+
   private
 
-  def new_button_data
-    if hotwire_native_modal?
-      {}
+  def button_data(data = {})
+    if feature_flag_native_modals_enabled?
+      data
     else
-      { turbo_frame: "modal" }
+      data.merge({ turbo_frame: "modal" })
     end
   end
 end

--- a/app/helpers/modal_helper.rb
+++ b/app/helpers/modal_helper.rb
@@ -12,7 +12,7 @@ module ModalHelper
             "ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto"
     text = "Cancel"
 
-    if hotwire_native_modal?
+    if feature_flag_native_modals_enabled?
       link_to text, turbo_resume_historical_location_url, class: clazz, "data-turbo-frame": "_top"
     elsif web_modal?
       button_tag text, class: clazz, "data-action": "modal#close", type: "button"

--- a/app/views/items/_menu.html.erb
+++ b/app/views/items/_menu.html.erb
@@ -11,7 +11,7 @@
     data-transition-leave-from="opacity-100 scale-100"
     data-transition-leave-to="opacity-0 scale-95"
   >
-  <%= link_to "Edit", [:edit, item], data: { action: "dropdown#toggle" }.merge(hotwire_native_app? ? {} : { turbo_frame: "modal" } ) , class: "edit block px-4 py-2 hover:bg-gray-100" %>
+    <%= edit_button([:edit, item]) %>
     <%= button_to "Delete", item, data: { action: "dropdown#toggle", "turbo-action": "replace" }, method: :delete, class: "destroy block px-4 py-2 hover:bg-gray-100 w-full text-left text-red-600" %>
   </div>
 </div>

--- a/app/views/lists/_menu.html.erb
+++ b/app/views/lists/_menu.html.erb
@@ -11,8 +11,7 @@
     data-transition-leave-from="opacity-100 scale-100"
     data-transition-leave-to="opacity-0 scale-95"
   >
-  <%= link_to "Show", list, "data-action": "dropdown#toggle", class: "show block px-4 py-2 hover:bg-gray-100" %>
-    <%= link_to "Edit", [:edit, list], data: { action: "dropdown#toggle" }.merge(hotwire_native_app? ? {} : { turbo_frame: "modal" } ), class: "edit block px-4 py-2 hover:bg-gray-100" %>
-  <%= button_to "Delete", list, data: { action: "dropdown#toggle", "turbo-action": "replace" }, method: :delete, class: "destroy block px-4 py-2 hover:bg-gray-100 w-full text-left text-red-600" %>
+    <%= edit_button([:edit, list]) %>
+    <%= button_to "Delete", list, data: { action: "dropdown#toggle", "turbo-action": "replace" }, method: :delete, class: "destroy block px-4 py-2 hover:bg-gray-100 w-full text-left text-red-600" %>
   </div>
 </div>

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -3,3 +3,4 @@ ignoreRegExpList:
   - clazz
   - hotwire
   - REFERER
+  - aronwolf

--- a/test/helpers/modal_helper_test.rb
+++ b/test/helpers/modal_helper_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class ModalHelperTest < ActionView::TestCase
   test "modal_close_button returns turbo_resume_historical_location_url link on hotwire native app" do
-    request.user_agent += ";overflow-menu"
+    request.user_agent += "feature-flag-native-modals;"
 
     html = controller.helpers.modal_close_button
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an "Edit" button for items and lists, providing a consistent and enhanced editing experience in dropdown menus.

- **Improvements**
	- Updated button helpers to support feature flag-based modal behavior and generalized data attribute handling.
	- Enhanced configuration for native modals with explicit URI and presentation settings.
	- Improved feature flag detection for native modal support.

- **Bug Fixes**
	- Ensured consistent behavior for modal close buttons based on updated feature flag logic.

- **Chores**
	- Updated spell checker configuration to ignore the term "aronwolf".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->